### PR TITLE
chore: bootstrap repo with README and upstream submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,10 @@
+[submodule "upstream/telegram-android"]
+	path = upstream/telegram-android
+	url = https://github.com/DrKLO/Telegram
+	branch = master
+
+[submodule "upstream/goodbyedpi"]
+	path = upstream/goodbyedpi
+	url = https://github.com/ValdikSS/GoodbyeDPI
+	branch = master
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
+<p align="center">
+  <img src="docs/assets/bypassgram_icon.png" width="192" alt="BypassGram logo"/>
+</p>
+
 # BypassGram
+
+**BypassGram** — форк Telegram-Android, который автоматически включает
+обход DPI-блокировок (ядро GoodByeDPI) **только во время звонков**.
+Никаких постоянных VPN-туннелей — экономим батарею и не затрагиваем
+другие приложения.
+
+[![Build](https://github.com/Locon213/BypassGram/actions/workflows/android.yml/badge.svg)](https://github.com/Locon213/BypassGram/actions)
+[![Release](https://img.shields.io/github/v/release/Locon213/BypassGram?label=latest)](https://github.com/Locon213/BypassGram/releases/latest)
+
+## ✨ Возможности
+* 🔐 GoodByeDPI внутри: фрагментация TLS, obfs SNI, split TCP.  
+* 📴 Туннель активен **только** во время звонка *Established*.  
+* ⚙️ Auto / Always / Off + плановые self-tests.  
+* 💤 Авто-off, если звонок > 30 мин и loss < 1 %.  
+* 🛠️ Nightly APK-сборки на Linux-runner (GitHub Actions).
+
+## 🚀 Установка
+1. Скачать APK из [Releases].  
+2. Разрешить установку.  
+3. В **Settings → Calls → DPI Bypass** выбрать *Auto*.
+
+[Releases]: https://github.com/Locon213/BypassGram/releases
+
+## 🧑‍💻 Сборка
+```bash
+git clone https://github.com/Locon213/BypassGram
+cd BypassGram
+./gradlew :app:assembleRelease      # Linux only
+
+🔬 Self-tests
+
+Настройка: Settings → DPI Bypass → Self-test.
+Проверяются RTT и loss, сохраняется лучшая MTU.
+📄 Лицензия
+Компонент	Лицензия
+Telegram-Android	GPL-3.0
+GoodByeDPI	Apache-2.0
+Tun2Socks-lite	MIT
+Наш код	GPL-3.0-or-later
+
+Полный текст — в LICENSE.
+<p align="center"> <a href="https://github.com/Locon213/BypassGram/releases/latest"> <img src="https://img.shields.io/badge/Download-APK-blue?logo=android&style=for-the-badge" alt="Download APK"/> </a> </p>
+
+Author / Maintainer: Locon213

--- a/init_sources.sh
+++ b/init_sources.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+# Ensure submodules directory exists
+mkdir -p upstream
+
+# Add upstream submodules
+if [ ! -d "upstream/telegram-android" ]; then
+  git submodule add https://github.com/DrKLO/Telegram upstream/telegram-android
+fi
+if [ ! -d "upstream/goodbyedpi" ]; then
+  git submodule add https://github.com/ValdikSS/GoodbyeDPI upstream/goodbyedpi
+fi
+
+# Pin submodules to HEAD of their master branches
+for dir in telegram-android goodbyedpi; do
+  git -C "upstream/$dir" fetch origin master
+  git -C "upstream/$dir" checkout "$(git -C "upstream/$dir" rev-parse origin/master)"
+  git add "upstream/$dir"
+done
+
+# Summary
+printf '%s\n' "Submodules added and pinned:" \
+  " - telegram-android @ $(git -C upstream/telegram-android rev-parse --short HEAD)" \
+  " - goodbyedpi       @ $(git -C upstream/goodbyedpi rev-parse --short HEAD)"
+


### PR DESCRIPTION
## Summary
- add detailed project README
- provide script to initialize upstream submodules
- configure submodule metadata

## Testing
- `shellcheck init_sources.sh`


------
https://chatgpt.com/codex/tasks/task_e_689e4eeff17c832ab35cb5ccfaf9b942