### PR TITLE
feat(dpi-core): add GoodByeDPI JNI wrapper module

### DIFF
--- a/dpi-core/build.gradle.kts
+++ b/dpi-core/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins { id("com.android.library") version "8.7.0" }
+
+android {
+    namespace = "org.bypassgram.dpi"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 26
+        ndk { abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64") }
+        externalNativeBuild.cmake.cppFlags += "-std=c11 -DANDROID"
+    }
+
+    externalNativeBuild.cmake {
+        path = file("src/main/cpp/CMakeLists.txt")
+        version = "3.28.0"
+    }
+
+    publishing {
+        singleVariant("release") { withSourcesJar() }
+    }
+}
+
+dependencies { /* none */ }

--- a/dpi-core/src/main/cpp/CMakeLists.txt
+++ b/dpi-core/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.28)
+project(dpi-core LANGUAGES C)
+
+set(CMAKE_C_STANDARD 11)
+add_library(dpi SHARED
+    ../../../../upstream/goodbyedpi/dpi.c
+    ../../../../upstream/goodbyedpi/tcp_fragment.c
+    ../../../../upstream/goodbyedpi/tls_fragment.c
+    DpiBridge.c
+)
+
+target_include_directories(dpi PRIVATE
+    ../../../../upstream/goodbyedpi
+    .
+)
+
+target_link_libraries(dpi log)

--- a/dpi-core/src/main/cpp/DpiBridge.c
+++ b/dpi-core/src/main/cpp/DpiBridge.c
@@ -1,0 +1,18 @@
+#include <jni.h>
+#include <stdint.h>
+#include "dpi.h"          // from GoodByeDPI
+
+JNIEXPORT jint JNICALL
+Java_org_bypassgram_dpi_DpiBridge_init(JNIEnv* env, jobject thiz, jint mtu) {
+    return dpi_init(mtu);
+}
+
+JNIEXPORT jint JNICALL
+Java_org_bypassgram_dpi_DpiBridge_process(JNIEnv* env, jobject thiz,
+                                          jbyteArray packet) {
+    jbyte* buf = (*env)->GetByteArrayElements(env, packet, NULL);
+    jint   len = (*env)->GetArrayLength(env, packet);
+    int    res = dpi_process((uint8_t*)buf, len);
+    (*env)->ReleaseByteArrayElements(env, packet, buf, 0);
+    return res;
+}

--- a/dpi-core/src/main/java/org/bypassgram/dpi/DpiBridge.kt
+++ b/dpi-core/src/main/java/org/bypassgram/dpi/DpiBridge.kt
@@ -1,0 +1,7 @@
+package org.bypassgram.dpi
+
+object DpiBridge {
+    init { System.loadLibrary("dpi") }
+    external fun init(mtu: Int): Int
+    external fun process(packet: ByteArray): Int
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,18 @@
+rootProject.name = "BypassGram"
+
+include(":TMessagesProj")
+project(":TMessagesProj").projectDir = file("upstream/telegram-android/TMessagesProj")
+
+include(":TMessagesProj_App")
+project(":TMessagesProj_App").projectDir = file("upstream/telegram-android/TMessagesProj_App")
+
+include(":TMessagesProj_AppHockeyApp")
+project(":TMessagesProj_AppHockeyApp").projectDir = file("upstream/telegram-android/TMessagesProj_AppHockeyApp")
+
+include(":TMessagesProj_AppStandalone")
+project(":TMessagesProj_AppStandalone").projectDir = file("upstream/telegram-android/TMessagesProj_AppStandalone")
+
+include(":TMessagesProj_AppTests")
+project(":TMessagesProj_AppTests").projectDir = file("upstream/telegram-android/TMessagesProj_AppTests")
+
+include(":dpi-core")


### PR DESCRIPTION
## Summary
- add dpi-core module wrapping GoodByeDPI
- expose JNI bridge for GoodByeDPI packet processing

## Testing
- `./gradlew :dpi-core:assemble` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e536d86ec832ab66013612ff47f73