### PR TITLE
build: switch to AGP 9.0.0-alpha01; move jvmToolchain to module level

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,3 @@ plugins {
     id("com.android.library") version "9.0.0-alpha01" apply false
     id("org.jetbrains.kotlin.android") version "2.2.0" apply false
 }
-
-kotlin {
-    jvmToolchain(21)
-}

--- a/dpi-core/build.gradle.kts
+++ b/dpi-core/build.gradle.kts
@@ -1,4 +1,7 @@
-plugins { id("com.android.library") version "9.0.0-alpha12" }
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
 
 android {
     namespace = "org.bypassgram.dpi"
@@ -19,6 +22,10 @@ android {
     publishing {
         singleVariant("release") { withSourcesJar() }
     }
+}
+
+kotlin {
+    jvmToolchain(21)
 }
 
 dependencies { /* none */ }


### PR DESCRIPTION
## Summary
- upgrade to Android Gradle Plugin 9.0.0-alpha01
- remove root Kotlin jvmToolchain block and configure it for the dpi-core module

## Testing
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_689e70527b30832aa9b610635bd67a94